### PR TITLE
Change cluster status of removed contexts to down (fixes #466).

### DIFF
--- a/job-server/config/shiro.ini.ldap.template
+++ b/job-server/config/shiro.ini.ldap.template
@@ -2,8 +2,10 @@
 #
 # use this for basic ldap authorization, without group checking
 activeDirectoryRealm = org.apache.shiro.realm.ldap.JndiLdapRealm
-# use this for checking group membership of users based on the 'member' attribute of the groups:
+# use this for checking group membership of users based on the 'member' or 'memberUid' attribute of the groups:
 # activeDirectoryRealm = spark.jobserver.auth.LdapGroupRealm
+# activeDirectoryRealm.userGroupAttribute = member
+# activeDirectoryRealm.userGroupAttribute = memberUid
 # search base for ldap groups (only relevant for LdapGroupRealm):
 activeDirectoryRealm.contextFactory.environment[ldap.searchBase] = dc=xxx,dc=org
 # allowed groups (only relevant for LdapGroupRealm):

--- a/job-server/src/spark.jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/spark.jobserver/AkkaClusterSupervisorActor.scala
@@ -151,7 +151,9 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef) extends InstrumentedActor {
     case StopContext(name) =>
       if (contexts contains name) {
         logger.info("Shutting down context {}", name)
-        contexts(name)._1 ! PoisonPill
+        val contextActorRef = contexts(name)._1
+        cluster.down(contextActorRef.path.address)
+        contextActorRef ! PoisonPill
         sender ! ContextStopped
       } else {
         sender ! NoSuchContext

--- a/job-server/test/spark.jobserver/auth/LdapGroupRealmSpec.scala
+++ b/job-server/test/spark.jobserver/auth/LdapGroupRealmSpec.scala
@@ -13,6 +13,10 @@ import javax.naming.ldap.LdapContext
 import javax.naming._
 import javax.naming.directory._
 
+object LdapGroupRealmSpec {
+   val memberAttributeName = "memberUid"
+}
+  
 class LdapGroupRealmSpec extends FunSpecLike with Matchers {
   import collection.JavaConverters._
 
@@ -21,6 +25,7 @@ class LdapGroupRealmSpec extends FunSpecLike with Matchers {
 # activeDirectoryRealm = org.apache.shiro.realm.ldap.JndiLdapRealm
 # use this for checking group membership of users based on the 'member' attribute of the groups:
 activeDirectoryRealm = spark.jobserver.auth.LdapGroupRealm
+activeDirectoryRealm.userGroupAttribute = """ + LdapGroupRealmSpec.memberAttributeName + """
 # search base for ldap groups:
 activeDirectoryRealm.contextFactory.environment[ldap.searchBase] = dc=xxx,dc=org
 activeDirectoryRealm.contextFactory.environment[ldap.allowedGroups] = "cn=group1,ou=groups", "", "cn=group2,ou=groups",,,,,
@@ -175,10 +180,10 @@ class TestLdapContext extends LdapContext {
   def rebind(x$1: Name, x$2: Any, x$3: directory.Attributes): Unit = ???
 
   def search(searchBase: String, searchFilter: String, searchAtts: Array[Object], searchCtls: SearchControls): NamingEnumeration[SearchResult] = {
-    if (searchFilter == LdapGroupRealm.groupMemberFilter) {
-      new TestNamingEnumeration(List(new SearchResult("cn=group1,ou=groups", null, new BasicAttributes("member", "cn=userInGroup1,ou=people,dc=xxx,dc=org")),
-        new SearchResult("cn=group2,ou=groups", null, new BasicAttributes("member", "cn=userInGroup2,ou=people,dc=xxx,dc=org")),
-        new SearchResult("cn=groupXX,ou=groups", null, new BasicAttributes("member", "cn=userInGroupXX,ou=people,dc=xxx,dc=org"))))
+    if (searchFilter.contains(LdapGroupRealmSpec.memberAttributeName)) {
+      new TestNamingEnumeration(List(new SearchResult("cn=group1,ou=groups", null, new BasicAttributes(LdapGroupRealmSpec.memberAttributeName, "cn=userInGroup1,ou=people,dc=xxx,dc=org")),
+        new SearchResult("cn=group2,ou=groups", null, new BasicAttributes(LdapGroupRealmSpec.memberAttributeName, "cn=userInGroup2,ou=people,dc=xxx,dc=org")),
+        new SearchResult("cn=groupXX,ou=groups", null, new BasicAttributes(LdapGroupRealmSpec.memberAttributeName, "cn=userInGroupXX,ou=people,dc=xxx,dc=org"))))
     } else {
       new TestNamingEnumeration(List(new SearchResult("cn=%s,ou=people" format searchAtts(0), null, new BasicAttributes("k", "v"))))
     }


### PR DESCRIPTION
Running jobserver with context-per-jvm results in remote jobmanager
actors, manually joining the jobserver cluster. After removing a
context, the actor stops and becomes unreachable within the cluster. We
have to manually remove the actor from the cluster (status down) before
the cluster accepts new clients again.

See http://doc.akka.io/docs/akka/2.3.15/scala/cluster-usage.html#Automatic_vs__Manual_Downing
Ticket: https://knime-com.atlassian.net/browse/BD-222
PR@spark-jobserver https://github.com/spark-jobserver/spark-jobserver/pull/624
Possible related issue: https://github.com/spark-jobserver/spark-jobserver/issues/466

I am not sure what our base branch is? This fix applies to all versions.
